### PR TITLE
hotfix for events with no proper vertices

### DIFF
--- a/Producers/interface/KMuonProducer.h
+++ b/Producers/interface/KMuonProducer.h
@@ -151,14 +151,23 @@ public:
 		if (in.globalTrack().isNonnull())
 			KTrackProducer::fillTrack(*in.globalTrack(), out.globalTrack);
 
-		reco::Vertex vtx = VertexHandle->at(0);
-		if (in.muonBestTrack().isNonnull()) // && &vtx != NULL) TODO
-		{
-			/// ID var from the bestTrack which is not saved entirely
-			out.dxy = in.bestTrack()->dxy(vtx.position()); //dxy from vertex should be using IPTools (e.g. like PAT)
-			out.dz = in.bestTrack()->dz(vtx.position());
-			out.relBestTrkErr = in.bestTrack()->pt() > 0 ? in.bestTrack()->ptError() / in.bestTrack()->pt() : -1;
-		}
+                if (VertexHandle->size() > 0)
+                {
+                        reco::Vertex vtx = VertexHandle->at(0);
+                        if (in.muonBestTrack().isNonnull()) // && &vtx != NULL) TODO
+                        {
+                                /// ID var from the bestTrack which is not saved entirely
+                                out.dxy = in.bestTrack()->dxy(vtx.position()); //dxy from vertex should be using IPTools (e.g. like PAT)
+                                out.dz = in.bestTrack()->dz(vtx.position());
+                                out.relBestTrkErr = in.bestTrack()->pt() > 0 ? in.bestTrack()->ptError() / in.bestTrack()->pt() : -1;
+                        }
+                }
+                else
+                {
+                        out.dxy = 99999.0;
+                        out.dz = 99999.0;
+                        out.relBestTrkErr = -1;
+                }
 		// propagated values of eta and phi
 		out.eta_propagated = -1000.;
 		out.phi_propagated = -1000.;
@@ -294,13 +303,17 @@ public:
 		out.ids = KLeptonId::ANY;
 		out.ids |= (muon::isLooseMuon(in)      << KLeptonId::LOOSE);
 		out.ids |= (isMediumMuon               << KLeptonId::MEDIUM);
-		out.ids |= (muon::isTightMuon(in, vtx) << KLeptonId::TIGHT);
-		out.ids |= (muon::isSoftMuon(in, vtx)  << KLeptonId::SOFT);
+                if (VertexHandle->size() > 0)
+                {
+                        reco::Vertex vtx = VertexHandle->at(0);
+                        out.ids |= (muon::isTightMuon(in, vtx) << KLeptonId::TIGHT);
+                        out.ids |= (muon::isSoftMuon(in, vtx)  << KLeptonId::SOFT);
 #if CMSSW_MAJOR_VERSION == 5 && CMSSW_MINOR_VERSION < 15
-		out.ids |= (muon::isHighPtMuon(in, vtx, reco::improvedTuneP) << KLeptonId::HIGHPT);
+                        out.ids |= (muon::isHighPtMuon(in, vtx, reco::improvedTuneP) << KLeptonId::HIGHPT);
 #else
-		out.ids |= (muon::isHighPtMuon(in, vtx) << KLeptonId::HIGHPT);
+                        out.ids |= (muon::isHighPtMuon(in, vtx) << KLeptonId::HIGHPT);
 #endif
+                }
 		assert((out.ids & 145) == 0); // 145 = 0b10010001, these bits should be zero
 	}
 

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -96,6 +96,13 @@ def getBaseConfig(
 	process.kappaTuple.verbose    = cms.int32(0)
 	# uncomment the following option to select only running on certain luminosity blocks. Use only for debugging
 	# process.source.lumisToProcess  = cms.untracked.VLuminosityBlockRange("1:500-1:1000")
+        #
+        # For the following dataset: /SingleMuon/Run2017C-PromptReco-v1/MINIAOD
+        # Event run: 299368 lumi: 83 event: 56418140 stream: 0
+        # A crash in the KMuonProducer is triggered, having a vertex, that cannot properly be used.
+        # It seems to be an event with a cosmic muon (use edmPickEvents.py and cmsShow on the corresponding RECO file)
+        # To check it, use the following single event processing option:
+        # process.source.eventsToProcess  = cms.untracked.VEventRange("299368:56418140-299368:56418140")
 	process.kappaTuple.profile    = cms.bool(True)
 
 	


### PR DESCRIPTION
After we have tried to skim the recent 2017 Data, we've encountered crashes of Kappa for events without proper vertices (in this case, its set to the beamspot). Looking at the RECO file, it seems to be an event with a cosmic muon, which produces entries in some muon chambers. Funny fact is that it triggers one of the HLT Single muon Triggers (based on L1, so not very accurate I guess).

For now it's just a hotfix to test, I'll let the skims run with it and look whether the crash still appears. It would be good to have such event filtered. But after trying to use the VertexSelector for this (with filter = True), kappa still uses the event, I guess because it's in the EndPath and not in the Path. And in EndPaths, it's not allowed to use Filters....

So let's think perhaps of more decent solutions to this 