### PR TITLE
enable stxs processing for CMSSW 9

### DIFF
--- a/Producers/interface/KGenInfoProducer.h
+++ b/Producers/interface/KGenInfoProducer.h
@@ -47,9 +47,7 @@ public:
 		puInfoSource(cfg.getParameter<edm::InputTag>("pileUpInfoSource")),
 		lheSource(cfg.getParameter<edm::InputTag>("lheSource")),
 		runInfo(cfg.getParameter<edm::InputTag>("lheSource")),
-#if CMSSW_MAJOR_VERSION < 9
 		htxsSource(cfg.getParameter<edm::InputTag>("htxsInfo")),
-#endif
 		lheWeightRegexes(cfg.getParameter<std::vector<std::string>>("lheWeightNames"))
 		{
 			this->tokenGenRunInfo = consumescollector.consumes<GenRunInfoProduct, edm::InRun>(tagSource);
@@ -58,9 +56,7 @@ public:
 			this->tokenPuInfo = consumescollector.consumes<std::vector<PileupSummaryInfo>>(puInfoSource);
 			//this->tokenLHERunInfo = consumescollector.consumes<LHERunInfoProduct, edm::InRun>(runInfo);
 			this->tokenRunInfo = consumescollector.consumes<LHERunInfoProduct, edm::InRun>(runInfo);
-#if CMSSW_MAJOR_VERSION < 9
 			this->htxsSrc = consumescollector.consumes<HTXS::HiggsClassification>(htxsSource);
-#endif
 
 			genEventInfoMetadata = new KGenEventInfoMetadata();
 			_lumi_tree->Bronch("genEventInfoMetadata", "KGenEventInfoMetadata", &genEventInfoMetadata);
@@ -213,7 +209,6 @@ public:
 		}
                 }
 
-#if CMSSW_MAJOR_VERSION < 9
 		// Get STXS infos
 		edm::Handle<HTXS::HiggsClassification> htxs;
 		event.getByToken(htxsSrc, htxs);
@@ -221,7 +216,6 @@ public:
 		this->metaEvent->htxs_stage1cat = htxs->stage1_cat_pTjet30GeV;
 		this->metaEvent->htxs_higgsPt = htxs->higgs.Pt();
 		this->metaEvent->htxs_njets30 = htxs->jets30.size();
-#endif
 
 		return true;
 	}
@@ -264,11 +258,7 @@ protected:
 	bool isEmbedded;
 	int forceLumi;
 	std::string binningMode;
-#if CMSSW_MAJOR_VERSION < 9
 	edm::InputTag tagSource, puInfoSource, lheSource, runInfo, htxsSource;
-#else
-	edm::InputTag tagSource, puInfoSource, lheSource, runInfo;
-#endif
 	KGenEventInfoMetadata *genEventInfoMetadata;
 	std::vector<std::string> lheWeightRegexes;
 
@@ -278,9 +268,7 @@ protected:
 	edm::EDGetTokenT<std::vector<PileupSummaryInfo>> tokenPuInfo;
 	//edm::EDGetTokenT<LHERunInfoProduct> tokenLHERunInfo;
 	edm::EDGetTokenT<LHERunInfoProduct> tokenRunInfo;
-#if CMSSW_MAJOR_VERSION < 9
 	edm::EDGetTokenT<HTXS::HiggsClassification> htxsSrc;
-#endif
 };
 
 template<typename Tmeta>

--- a/Skimming/higgsTauTau/kSkimming_run2_cfg.py
+++ b/Skimming/higgsTauTau/kSkimming_run2_cfg.py
@@ -126,23 +126,24 @@ def getBaseConfig(
 	if not tools.is_above_cmssw_version([9]):
             if isSignal:
 		process.kappaTuple.Info.lheSource = cms.InputTag("source")
-	if (tools.is_above_cmssw_version([8]) and not tools.is_above_cmssw_version([9])) and not data and not isEmbedded:
+	if tools.is_above_cmssw_version([8]) and not data and not isEmbedded:
 		process.kappaTuple.Info.htxsInfo = cms.InputTag("rivetProducerHTXS", "HiggsClassification")
 		process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 		process.mergedGenParticles = cms.EDProducer("MergedGenParticleProducer",
 			inputPruned = cms.InputTag("prunedGenParticles"),
 			inputPacked = cms.InputTag("packedGenParticles"),
 		)
-		process.myGenerator = cms.EDProducer("GenParticles2HepMCConverterHTXS",
+		process.myGenerator = cms.EDProducer("GenParticles2HepMCConverter",
 			genParticles = cms.InputTag("mergedGenParticles"),
 			genEventInfo = cms.InputTag("generator"),
+			signalParticlePdgIds = cms.vint32(25),
 		)
 		process.rivetProducerHTXS = cms.EDProducer('HTXSRivetProducer',
 			HepMCCollection = cms.InputTag('myGenerator','unsmeared'),
 			LHERunInfo = cms.InputTag('externalLHEProducer'),
 			ProductionMode = cms.string('AUTO'),
 		)
-		process.p *= cms.Path(process.mergedGenParticles*process.myGenerator*process.rivetProducerHTXS)
+		process.p *= cms.Sequence(process.mergedGenParticles*process.myGenerator*process.rivetProducerHTXS)
 
 	# save primary vertex
 	process.kappaTuple.active += cms.vstring('VertexSummary') # save VertexSummary

--- a/Skimming/scripts/checkoutCmssw94xPackagesForSkimming.sh
+++ b/Skimming/scripts/checkoutCmssw94xPackagesForSkimming.sh
@@ -4,8 +4,8 @@ set -e # exit on errors
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 source $VO_CMS_SW_DIR/cmsset_default.sh
 
-scramv1 project CMSSW_9_4_9
-cd CMSSW_9_4_9/src
+scramv1 project CMSSW_9_4_10
+cd CMSSW_9_4_10/src
 eval `scramv1 runtime -sh`
 
 git cms-init
@@ -23,6 +23,13 @@ git clone https://github.com/janekbechtel/grid-control.git
 # Get python code to rerun Tau ID's
 cd Kappa/Skimming/python
 wget https://raw.githubusercontent.com/greyxray/TauAnalysisTools/CMSSW_9_4_X_tau-pog_RunIIFall17/TauAnalysisTools/python/runTauIdMVA.py
+cd -
+
+# Get working version of HTXSRivetProducer
+git cms-addpkg GeneratorInterface/RivetInterface
+cd GeneratorInterface/RivetInterface/plugins
+rm HTXSRivetProducer.cc
+wget https://raw.githubusercontent.com/perrozzi/cmssw/HTXS_clean/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
 cd -
 
 scram b -j 4


### PR DESCRIPTION
checkout script was adapted to create a runnable setup for stxs in CMSSW 9. Corresponding protecting version requirements in the code were removed. Some additional updates are applied.