### PR TITLE
Fix cone size for Muon Iso Run II

### DIFF
--- a/DataFormats/interface/KLepton.h
+++ b/DataFormats/interface/KLepton.h
@@ -43,7 +43,11 @@ struct KLepton : public KLV
 	float sumNeutralHadronEt;  //< sum Et of neutral hadrons for isolation
 	float sumPhotonEt;         //< sum Et of photons for isolation
 	float sumPUPt;             //< sum pt of pile-up for isolation
-	float sumChargedAllPt;     //< sum pt of charged hadrons for isolation // TODO: not filled. Remove for next dictchange
+	float sumChargedHadronPtR04;  //< sum pt of charged hadrons for isolation
+	float sumNeutralHadronEtR04;  //< sum Et of neutral hadrons for isolation
+	float sumPhotonEtR04;         //< sum Et of photons for isolation
+	float sumPUPtR04;             //< sum pt of pile-up for isolation
+//	float sumChargedAllPt;     //< sum pt of charged hadrons for isolation // TODO: not filled. Remove for next dictchange
 	float dz;                  //< impact parameter in z direction
 	float dxy;                 //< impact parameter in transverse plane
 	KTrack track;              //< (main) track of the lepton (e: GSF, mu: inner, tau: lead. PF candidate)
@@ -77,6 +81,14 @@ struct KLepton : public KLV
 		return sumChargedHadronPt + std::max(0.0f,
 			sumNeutralHadronEt + sumPhotonEt - puFraction * sumPUPt);
 	}
+
+    // PF Isolateion for Run 2 with cone size 0.4
+	inline float pfIsoR04(const float puFraction=0.5) const
+	{
+		return sumChargedHadronPtR04 + std::max(0.0f,
+			sumNeutralHadronEtR04 + sumPhotonEtR04 - puFraction * sumPUPtR04);
+	}
+
 	
 	// (signed) PDG ID
 	int pdgId() const

--- a/DataFormats/interface/KMuon.h
+++ b/DataFormats/interface/KMuon.h
@@ -78,7 +78,7 @@ struct KMuon : public KLepton
 	float hcalIso;          //< hcal detector based isolation as given by muon.isolationR03().hadEt
 	float ecalIso;          //< ecal detector basedisolation as given by muon.isolationR03().emEt
 	float pfIso03;          //< PF isolation R = 0.3
-	float pfIso04;          //< PF isolation R = 0.3
+	float pfIso04;          //< PF isolation R = 0.4
 	// deleted: hcalIso03, ecalIso03 and all 05
 
 	/// additional isolation variables for PF isolation which are not stored in a KLepton


### PR DESCRIPTION
Add function and variables for R=0.4 cone size for Muon Isolation