### PR TITLE
[KElectronProducer] [BUGFIX] Only append inexistent IDs on new lumi section

### DIFF
--- a/Producers/interface/KElectronProducer.h
+++ b/Producers/interface/KElectronProducer.h
@@ -68,15 +68,20 @@ public:
 
 	virtual bool onLumi(const edm::LuminosityBlock &lumiBlock, const edm::EventSetup &setup)
 	{
-		for (size_t j = 0; j < tagOfIds.size(); ++j)
+		// NOTE: identical implementation for storing names of electron ID and other userFloats
+		for (const auto& tag : this->tagOfIds)
 		{
-			std::cout << this->tagOfIds[j].label() << ":" << this->tagOfIds[j].instance() << std::endl;
-			electronMetadata->idNames.push_back(this->tagOfIds[j].label()+":"+this->tagOfIds[j].instance());
+			std::string metadataKey = tag.label() + ":" + tag.instance();
+			if (std::find(electronMetadata->idNames.begin(), electronMetadata->idNames.end(), metadataKey) == electronMetadata->idNames.end()) {
+				electronMetadata->idNames.push_back(metadataKey);
+			}
 		}
-		for (size_t j = 0; j < tagOfUserFloats.size(); ++j)
+		for (const auto& tag : this->tagOfUserFloats)
 		{
-			std::cout << this->tagOfUserFloats[j].label() << ":" << this->tagOfUserFloats[j].instance() << std::endl;
-			electronMetadata->idNames.push_back(this->tagOfUserFloats[j].label()+":"+this->tagOfUserFloats[j].instance());
+			std::string metadataKey = tag.label() + ":" + tag.instance();
+			if (std::find(electronMetadata->idNames.begin(), electronMetadata->idNames.end(), metadataKey) == electronMetadata->idNames.end()) {
+				electronMetadata->idNames.push_back(metadataKey);
+			}
 		}
 		return KBaseMultiLVProducer<edm::View<pat::Electron>, KElectrons>::onLumi(lumiBlock, setup);
 	}


### PR DESCRIPTION
**Bug**: the entire list of electron ID and userFloat names ("keys") was appended to the electron metadata on every lumi section without clearing the old list, resulting in unwanted duplicates. These cause uniqueness assertions to fail down the line in `Artus`/`Excalibur` and lead to unnecessarily bloated skims. The bug seems to be several years old.

**Proposed fix**: following the implementation in [`KPatJetProducer`](https://github.com/KIT-CMS/Kappa/blob/8dd53de342de7409aace1b47fabec889b7de81ef/Producers/interface/KPatJetProducer.h#L45-L48),
keys are now only appended to the electron metadata if no entry exists (the list is now effectively an indexed set).